### PR TITLE
Gunner fixes: AB detonation, MM, RR

### DIFF
--- a/config/skills.js
+++ b/config/skills.js
@@ -2746,7 +2746,10 @@ module.exports = {
 				noInterrupt: [7],
 				noRetry: true
 			},
-			3: { length: 1200 }
+			3: {
+				requiredBuff: 10152040,  
+				length: 1200
+			}
 		},
 		9: { // Mana Missiles
 			'*': {
@@ -2755,7 +2758,7 @@ module.exports = {
 			},
 			0: {
 				type: 'charging',
-				length: 1200 // Advised to set a bit longer, like 1300, because otherwise auto-release full charge will shoot 2 missiles in reality
+				length: 1280 
 			},
 			10: { distance: -50 },
 			11: { distance: -100 }
@@ -2873,7 +2876,7 @@ module.exports = {
 		40: { // Rolling Reload
 			0: {
 				fixedSpeed: 1,
-				length: 800,
+				length: 910, //800 in original SP
 				distance: 172.5,
 				forceClip: true
 			}

--- a/skills.js
+++ b/skills.js
@@ -1,13 +1,13 @@
 const JITTER_COMPENSATION	= true,
 	JITTER_ADJUST			= 0,		//	This number is added to your detected minimum ping to get the compensation amount.
-	SKILL_RETRY_COUNT		= 2,		//	Number of times to retry each skill (0 = disabled). Recommended 1-3.
+	SKILL_RETRY_COUNT		= 1,		//	Number of times to retry each skill (0 = disabled). Recommended 1-3.
 	SKILL_RETRY_MS			= 30,		/*	Time to wait between each retry.
 											SKILL_RETRY_MS * SKILL_RETRY_COUNT should be under 100, otherwise skills may go off twice.
 										*/
 	SKILL_RETRY_JITTERCOMP	= 15,		//	Skills that support retry will be sent this much earlier than estimated by jitter compensation.
 	SKILL_RETRY_ALWAYS		= false,	//	Setting this to true will reduce ghosting for extremely short skills, but may cause other skills to fail.
 	SKILL_DELAY_ON_FAIL		= true,		//	Basic initial desync compensation. Useless at low ping (<50ms).
-	SERVER_TIMEOUT			= 200,		/*	This number is added to your maximum ping + skill retry period to set the failure threshold for skills.
+	SERVER_TIMEOUT			= 350,	/* 200 by default		This number is added to your maximum ping + skill retry period to set the failure threshold for skills.
 											If animations are being cancelled while damage is still applied, increase this number.
 										*/
 	FORCE_CLIP_STRICT		= true,		/*	Set this to false for smoother, less accurate iframing near walls.


### PR DESCRIPTION
AB detonation: gunner was allowed to do multiple fake detonations (with wrong client-side animation)
MM: increased length by default (default value was so unstable)
RR: fixed wrong length (wrong animation for some skills after RR)